### PR TITLE
2 splits, not 3 in "pattern, search, replace = line.split(None, 3)"

### DIFF
--- a/examples/plural4.py
+++ b/examples/plural4.py
@@ -17,7 +17,7 @@ def build_match_and_apply_functions(pattern, search, replace):
 rules = []
 with open('plural4-rules.txt', encoding='utf-8') as pattern_file:
     for line in pattern_file:
-        pattern, search, replace = line.split(None, 3)
+        pattern, search, replace = line.split(None, 2)
         rules.append(build_match_and_apply_functions(
                 pattern, search, replace))
 

--- a/examples/plural5.py
+++ b/examples/plural5.py
@@ -17,7 +17,7 @@ def build_match_and_apply_functions(pattern, search, replace):
 def rules(rules_filename):
     with open(rules_filename, encoding='utf-8') as pattern_file:
         for line in pattern_file:
-            pattern, search, replace = line.split(None, 3)
+            pattern, search, replace = line.split(None, 2)
             yield build_match_and_apply_functions(pattern, search, replace)
 
 def plural(noun, rules_filename='plural5-rules.txt'):

--- a/examples/plural6.py
+++ b/examples/plural6.py
@@ -38,7 +38,7 @@ class LazyRules:
             self.pattern_file.close()
             raise StopIteration
 
-        pattern, search, replace = line.split(None, 3)
+        pattern, search, replace = line.split(None, 2)
         funcs = build_match_and_apply_functions(
             pattern, search, replace)
         self.cache.append(funcs)

--- a/generators.html
+++ b/generators.html
@@ -274,14 +274,14 @@ $                    $    s</code></pre>
 rules = []
 <a>with open('plural4-rules.txt', encoding='utf-8') as pattern_file:  <span class=u>&#x2461;</span></a>
 <a>    for line in pattern_file:                                      <span class=u>&#x2462;</span></a>
-<a>        pattern, search, replace = line.split(None, 3)             <span class=u>&#x2463;</span></a>
+<a>        pattern, search, replace = line.split(None, 2)             <span class=u>&#x2463;</span></a>
 <a>        rules.append(build_match_and_apply_functions(              <span class=u>&#x2464;</span></a>
                 pattern, search, replace))</code></pre>
 <ol>
 <li>The <code>build_match_and_apply_functions()</code> function has not changed. You&#8217;re still using closures to build two functions dynamically that use variables defined in the outer function.
 <li>The global <code>open()</code> function opens a file and returns a file object. In this case, the file we&#8217;re opening contains the pattern strings for pluralizing nouns. The <code>with</code> statement creates what&#8217;s called a <i>context</i>: when the <code>with</code> block ends, Python will automatically close the file, even if an exception is raised inside the <code>with</code> block. You&#8217;ll learn more about <code>with</code> blocks and file objects in the <a href=files.html>Files</a> chapter.
 <li>The <code>for line in &lt;fileobject></code> idiom reads data from the open file, one line at a time, and assigns the text to the <var>line</var> variable. You&#8217;ll learn more about reading from files in the <a href=files.html>Files</a> chapter.
-<li>Each line in the file really has three values, but they&#8217;re separated by whitespace (tabs or spaces, it makes no difference). To split it out, use the <code>split()</code> string method. The first argument to the <code>split()</code> method is <code>None</code>, which means &#8220;split on any whitespace (tabs or spaces, it makes no difference).&#8221; The second argument is <code>3</code>, which means &#8220;split on whitespace 3 times, then leave the rest of the line alone.&#8221; A line like <code>[sxz]$ $ es</code> will be broken up into the list <code>['[sxz]$', '$', 'es']</code>, which means that <var>pattern</var> will get <code>'[sxz]$'</code>, <var>search</var> will get <code>'$'</code>, and <var>replace</var> will get <code>'es'</code>. That&#8217;s a lot of power in one little line of code.
+<li>Each line in the file really has three values, but they&#8217;re separated by whitespace (tabs or spaces, it makes no difference). To split it out, use the <code>split()</code> string method. The first argument to the <code>split()</code> method is <code>None</code>, which means &#8220;split on any whitespace (tabs or spaces, it makes no difference).&#8221; The second argument is <code>2</code>, which means &#8220;split on whitespace 2 times, then leave the rest of the line alone.&#8221; A line like <code>[sxz]$ $ es</code> will be broken up into the list <code>['[sxz]$', '$', 'es']</code>, which means that <var>pattern</var> will get <code>'[sxz]$'</code>, <var>search</var> will get <code>'$'</code>, and <var>replace</var> will get <code>'es'</code>. That&#8217;s a lot of power in one little line of code.
 <li>Finally, you pass <code>pattern</code>, <code>search</code>, and <code>replace</code> to the <code>build_match_and_apply_functions()</code> function, which returns a tuple of functions. You append this tuple to the <var>rules</var> list, and <var>rules</var> ends up storing the list of match and apply functions that the <code>plural()</code> function expects.
 </ol>
 
@@ -297,7 +297,7 @@ rules = []
 <pre class='nd pp'><code>def rules(rules_filename):
     with open(rules_filename, encoding='utf-8') as pattern_file:
         for line in pattern_file:
-            pattern, search, replace = line.split(None, 3)
+            pattern, search, replace = line.split(None, 2)
             yield build_match_and_apply_functions(pattern, search, replace)
 
 def plural(noun, rules_filename='plural5-rules.txt'):
@@ -377,7 +377,7 @@ def plural(noun, rules_filename='plural5-rules.txt'):
 <pre class=pp><code>def rules(rules_filename):
     with open(rules_filename, encoding='utf-8') as pattern_file:
         for line in pattern_file:
-<a>            pattern, search, replace = line.split(None, 3)                   <span class=u>&#x2460;</span></a>
+<a>            pattern, search, replace = line.split(None, 2)                   <span class=u>&#x2460;</span></a>
 <a>            yield build_match_and_apply_functions(pattern, search, replace)  <span class=u>&#x2461;</span></a>
 
 def plural(noun, rules_filename='plural5-rules.txt'):
@@ -386,7 +386,7 @@ def plural(noun, rules_filename='plural5-rules.txt'):
             return apply_rule(noun)
     raise ValueError('no matching rule for {0}'.format(noun))</code></pre>
 <ol>
-<li>No magic here. Remember that the lines of the rules file have three values separated by whitespace, so you use <code>line.split(None, 3)</code> to get the three &#8220;columns&#8221; and assign them to three local variables.
+<li>No magic here. Remember that the lines of the rules file have three values separated by whitespace, so you use <code>line.split(None, 2)</code> to get the three &#8220;columns&#8221; and assign them to three local variables.
 <li><em>And then you yield.</em> What do you yield? Two functions, built dynamically with your old friend, <code>build_match_and_apply_functions()</code>, which is identical to the previous examples. In other words, <code>rules()</code> is a generator that spits out match and apply functions <em>on demand</em>.
 <li>Since <code>rules()</code> is a generator, you can use it directly in a <code>for</code> loop. The first time through the <code>for</code> loop, you will call the <code>rules()</code> function, which will open the pattern file, read the first line, dynamically build a match function and an apply function from the patterns on that line, and yield the dynamically built functions. The second time through the <code>for</code> loop, you will pick up exactly where you left off in <code>rules()</code> (which was in the middle of the <code>for line in pattern_file</code> loop). The first thing it will do is read the next line of the file (which is still open), dynamically build another match and apply function based on the patterns on that line in the file, and yield the two functions.
 </ol>

--- a/iterators.html
+++ b/iterators.html
@@ -236,7 +236,7 @@ All three of these class methods, <code>__init__</code>, <code>__iter__</code>, 
             self.pattern_file.close()
             raise StopIteration
 
-        pattern, search, replace = line.split(None, 3)
+        pattern, search, replace = line.split(None, 2)
         funcs = build_match_and_apply_functions(
             pattern, search, replace)
         self.cache.append(funcs)
@@ -304,7 +304,7 @@ rules = LazyRules()</code></pre>
         .
         .
         .
-        pattern, search, replace = line.split(None, 3)
+        pattern, search, replace = line.split(None, 2)
 <a>        funcs = build_match_and_apply_functions(        <span class=u>&#x2461;</span></a>
             pattern, search, replace)
 <a>        self.cache.append(funcs)                        <span class=u>&#x2462;</span></a>


### PR DESCRIPTION
Changed 3 to 2 in this line of code, in several places in  in 6.5, 6.6, 7.6, and in example code files. Two splits give three values. (Maybe line.split() with no args would be easier in this case?) See http://docs.python.org/3.3/library/stdtypes.html#str.split
