### PR TITLE
Cannot explicitly set an encoding with a unicode string

### DIFF
--- a/util/validate.py
+++ b/util/validate.py
@@ -9,7 +9,7 @@ input_filename = sys.argv[1]
 parser = html5lib.HTMLParser()
 with open(input_filename, encoding='utf-8') as stream:
     data = stream.read()
-html5doc = parser.parse(data, encoding='utf-8')
+html5doc = parser.parse(data)
 if parser.errors:
     for ((line, column), errtype, params) in parser.errors:
         print("Error: {} {} on line {} of {}".format(errtype, repr(params), line, input_filename), file=sys.stderr)


### PR DESCRIPTION
Publish script throws an exception:

```
started build
validating HTML
Traceback (most recent call last):
  File "util/validate.py", line 12, in <module>
    html5doc = parser.parse(data, encoding='utf-8')
  File "/usr/lib/python3/dist-packages/html5lib/html5parser.py", line 224, in parse
    parseMeta=parseMeta, useChardet=useChardet)
  File "/usr/lib/python3/dist-packages/html5lib/html5parser.py", line 88, in _parse
    parser=self, **kwargs)
  File "/usr/lib/python3/dist-packages/html5lib/tokenizer.py", line 40, in __init__
    self.stream = HTMLInputStream(stream, encoding, parseMeta, useChardet)
  File "/usr/lib/python3/dist-packages/html5lib/inputstream.py", line 133, in HTMLInputStream
    raise TypeError("Cannot explicitly set an encoding with a unicode string")
TypeError: Cannot explicitly set an encoding with a unicode string
Failed to validate about.html
```

I ran it on Arch so my first guess was that it's html5lib package's fault but it doesn't work on other distros and html5lib versions too:

Ubuntu 14.04
Python 3.4.3 (default, Oct 14 2015, 20:33:09) [GCC 4.8.4] on linux
python3-html5lib/trusty-updates,now 0.999-3~ubuntu1 all [installed]

Ubuntu 16.04
Python 3.5.2 (default, Jul 5 2016, 12:43:10) [GCC 5.4.0 20160609] on linux
python3-html5lib/xenial,xenial,now 0.999-4

Archlinux
Python 3.5.2 (default, Jun 28 2016, 08:46:01) [GCC 6.1.1 20160602] on linux
python-html5lib 0.9999999-2
